### PR TITLE
Fix file download bug in released version

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,9 @@ pub struct DirectoryItem {
     pub depth: usize,
     pub selected: bool,
     pub preview: String,
+    // This field is not serialized and is only used on the host side for path resolution
+    #[serde(skip)]
+    pub absolute_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -193,6 +196,7 @@ impl App {
             depth,
             selected,
             preview,
+            absolute_path: None,
         }
     }
 


### PR DESCRIPTION
The file download issue in release mode was due to inverted file transfer logic and incorrect path resolution.

The fix involved:
*   **Correcting File Transfer Flow**:
    *   Previously, the client attempted to *send* files when requesting downloads, and the host tried to *receive*.
    *   The logic in `src/service/node.rs` was reversed: the client now sends a file path request, then receives the file data. The host receives the request, resolves the path, and sends the file.
*   **Implementing Absolute Path Resolution**:
    *   A `absolute_path: Option<PathBuf>` field was added to `DirectoryItem` in `src/app.rs`, marked with `%23[serde(skip)]` to prevent network serialization.
    *   In `src/main.rs`, `handle_host_mode` was updated to populate this `absolute_path` when sharing items.
    *   In `src/service/node.rs`, a `path_mappings: HashMap<PeerId, HashMap<String, PathBuf>>` was added to `EventLoop`.
    *   The `InsertDirectoryItems` command handler now populates this `path_mappings` with absolute paths.
    *   The host's incoming stream handler uses these mappings to find the actual file location when a download is requested, ensuring files are found regardless of the working directory.

These changes ensure the host correctly identifies and serves files using absolute paths, resolving the discrepancy between debug and release environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file transfer protocol to support bidirectional, request-response style transfers, allowing clients to explicitly request files by path and hosts to respond with the correct file.
- **Improvements**
  - Improved accuracy of file location resolution by using absolute paths during file sharing and transfer.
  - Added internal mechanisms to manage and map shared file paths for more reliable file transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->